### PR TITLE
test: openid client test case correction

### DIFF
--- a/server/src/test/resources/feature/openid/clients/clients.feature
+++ b/server/src/test/resources/feature/openid/clients/clients.feature
@@ -56,8 +56,9 @@ Then status 200
 And print response
 Given url mainUrl
 And header Authorization = 'Bearer ' + accessToken
-And param pattern = response[0].displayName
-And print 'pattern = '+pattern 
+And def search_str = response[0].inum
+And param pattern = search_str
+And print search_str 
 When method GET
 Then status 200
 And print response


### PR DESCRIPTION
@yuriyz , request review
Modified openid client test case for search pattern to resolve the build issue
`src.test.resources.feature.openid.clients.clients: clients.feature:59 - javascript evaluation failed: response[0].displayName, TypeError: Cannot read property "displayName" from undefined in <eval> at line number 1`