### PR TITLE
fix: swagger- Operation_Id of two endpoints are same #90

### DIFF
--- a/docs/jans-config-api-swagger.yaml
+++ b/docs/jans-config-api-swagger.yaml
@@ -2805,7 +2805,7 @@ paths:
     get:
       summary: Returns auth server health status.
       description: Returns auth server health status.
-      operationId: get-config-health-ready
+      operationId: get-auth-server-health
       tags:
         - Auth Server Health - Check
       responses:


### PR DESCRIPTION
https://github.com/JanssenProject/jans-config-api/issues/90